### PR TITLE
Flex basis alias support

### DIFF
--- a/src/lib/flex-attributes.scss
+++ b/src/lib/flex-attributes.scss
@@ -6,11 +6,31 @@
 		@include flex-properties;
 	}
 
+	*[data-fx-flex-auto] {
+		@include flex-auto-properties;
+	}
+
 	*[data-fx-flex-grow] {
 		@include flex-grow-properties;
 	}
 
-	*:has(>[data-fx-flex],>[data-fx-flex-grow]):not([data-layout]) {
+	*[data-fx-flex-initial] {
+		@include flex-initial-properties;
+	}
+
+	*[data-fx-flex-none] {
+		@include flex-none-properties;
+	}
+
+	*[data-fx-flex-nogrow] {
+		@include flex-nogrow-properties;
+	}
+
+	*[data-fx-flex-noshrink] {
+		@include flex-noshrink-properties;
+	}
+
+	*:has(>[data-fx-flex],>[data-fx-flex-auto],>[data-fx-flex-grow],>[data-fx-flex-initial],>[data-fx-flex-none],>[data-fx-flex-nogrow],>[data-fx-flex-noshrink]):not([data-layout]) {
 		@include flex-row-properties;
 	}
 }
@@ -23,8 +43,28 @@
 				@include flex-properties;
 			}
 
+			*[data-fx-flex-auto-#{$name}] {
+				@include flex-auto-properties;
+			}
+
 			*[data-fx-flex-grow-#{$name}] {
 				@include flex-grow-properties;
+			}
+
+			*[data-fx-flex-initial-#{$name}] {
+				@include flex-initial-properties;
+			}
+
+			*[data-fx-flex-none-#{$name}] {
+				@include flex-none-properties;
+			}
+
+			*[data-fx-flex-nogrow-#{$name}] {
+				@include flex-nogrow-properties;
+			}
+
+			*[data-fx-flex-noshrink-#{$name}] {
+				@include flex-noshrink-properties;
 			}
 		}
 	}

--- a/src/lib/flex-attributes.scss
+++ b/src/lib/flex-attributes.scss
@@ -39,7 +39,7 @@
 	}
 }
 
-// these do not automatically add flex to their parent container
+/// Generates flex data-attribute selectors for media sizes
 @mixin flex-attributes-for-media-sizes {
 	@each $name, $_ in $flex-layout-media-queries {
 		@include flex-layout-media($name) {
@@ -73,6 +73,10 @@
 
 			*[data-fx-flex-#{$name}="noshrink"] {
 				@include flex-noshrink-properties;
+			}
+
+			*:has(>[data-fx-flex-#{$name}],>[data-fx-flex-grow-#{$name}]):not([data-layout]) {
+				@include flex-row-properties;
 			}
 		}
 	}

--- a/src/lib/flex-attributes.scss
+++ b/src/lib/flex-attributes.scss
@@ -6,31 +6,35 @@
 		@include flex-properties;
 	}
 
-	*[data-fx-flex-auto] {
+	*[data-fx-flex^="auto"] {
 		@include flex-auto-properties;
+	}
+
+	*[data-fx-flex^="grow"] {
+		@include flex-grow-properties;
 	}
 
 	*[data-fx-flex-grow] {
 		@include flex-grow-properties;
 	}
-
-	*[data-fx-flex-initial] {
+	
+	*[data-fx-flex^="initial"] {
 		@include flex-initial-properties;
 	}
 
-	*[data-fx-flex-none] {
+	*[data-fx-flex^="none"] {
 		@include flex-none-properties;
 	}
-
-	*[data-fx-flex-nogrow] {
+	
+	*[data-fx-flex^="nogrow"] {
 		@include flex-nogrow-properties;
 	}
-
-	*[data-fx-flex-noshrink] {
+	
+	*[data-fx-flex^="noshrink"] {
 		@include flex-noshrink-properties;
 	}
 
-	*:has(>[data-fx-flex],>[data-fx-flex-auto],>[data-fx-flex-grow],>[data-fx-flex-initial],>[data-fx-flex-none],>[data-fx-flex-nogrow],>[data-fx-flex-noshrink]):not([data-layout]) {
+	*:has(>[data-fx-flex],>[data-fx-flex-grow]):not([data-layout]) {
 		@include flex-row-properties;
 	}
 }
@@ -40,30 +44,34 @@
 	@each $name, $_ in $flex-layout-media-queries {
 		@include flex-layout-media($name) {
 			*[data-fx-flex-#{$name}] {
+				@include flex-auto-properties;
+			}
+
+			*[data-fx-flex-#{$name}^="auto"] {
 				@include flex-properties;
 			}
 
-			*[data-fx-flex-auto-#{$name}] {
-				@include flex-auto-properties;
+			*[data-fx-flex-#{$name}^="grow"] {
+				@include flex-grow-properties;
 			}
 
 			*[data-fx-flex-grow-#{$name}] {
 				@include flex-grow-properties;
 			}
 
-			*[data-fx-flex-initial-#{$name}] {
+			*[data-fx-flex-#{$name}^="initial"] {
 				@include flex-initial-properties;
 			}
 
-			*[data-fx-flex-none-#{$name}] {
+			*[data-fx-flex-#{$name}^="none"] {
 				@include flex-none-properties;
 			}
 
-			*[data-fx-flex-nogrow-#{$name}] {
+			*[data-fx-flex-#{$name}^="nogrow"] {
 				@include flex-nogrow-properties;
 			}
 
-			*[data-fx-flex-noshrink-#{$name}] {
+			*[data-fx-flex-#{$name}^="noshrink"] {
 				@include flex-noshrink-properties;
 			}
 		}

--- a/src/lib/flex-attributes.scss
+++ b/src/lib/flex-attributes.scss
@@ -6,11 +6,11 @@
 		@include flex-properties;
 	}
 
-	*[data-fx-flex^="auto"] {
+	*[data-fx-flex="auto"] {
 		@include flex-auto-properties;
 	}
 
-	*[data-fx-flex^="grow"] {
+	*[data-fx-flex="grow"] {
 		@include flex-grow-properties;
 	}
 
@@ -18,19 +18,19 @@
 		@include flex-grow-properties;
 	}
 	
-	*[data-fx-flex^="initial"] {
+	*[data-fx-flex="initial"] {
 		@include flex-initial-properties;
 	}
 
-	*[data-fx-flex^="none"] {
+	*[data-fx-flex="none"] {
 		@include flex-none-properties;
 	}
 	
-	*[data-fx-flex^="nogrow"] {
+	*[data-fx-flex="nogrow"] {
 		@include flex-nogrow-properties;
 	}
 	
-	*[data-fx-flex^="noshrink"] {
+	*[data-fx-flex="noshrink"] {
 		@include flex-noshrink-properties;
 	}
 
@@ -47,11 +47,11 @@
 				@include flex-auto-properties;
 			}
 
-			*[data-fx-flex-#{$name}^="auto"] {
+			*[data-fx-flex-#{$name}="auto"] {
 				@include flex-properties;
 			}
 
-			*[data-fx-flex-#{$name}^="grow"] {
+			*[data-fx-flex-#{$name}="grow"] {
 				@include flex-grow-properties;
 			}
 
@@ -59,19 +59,19 @@
 				@include flex-grow-properties;
 			}
 
-			*[data-fx-flex-#{$name}^="initial"] {
+			*[data-fx-flex-#{$name}="initial"] {
 				@include flex-initial-properties;
 			}
 
-			*[data-fx-flex-#{$name}^="none"] {
+			*[data-fx-flex-#{$name}="none"] {
 				@include flex-none-properties;
 			}
 
-			*[data-fx-flex-#{$name}^="nogrow"] {
+			*[data-fx-flex-#{$name}="nogrow"] {
 				@include flex-nogrow-properties;
 			}
 
-			*[data-fx-flex-#{$name}^="noshrink"] {
+			*[data-fx-flex-#{$name}="noshrink"] {
 				@include flex-noshrink-properties;
 			}
 		}

--- a/src/lib/flex-attributes.scss
+++ b/src/lib/flex-attributes.scss
@@ -44,11 +44,11 @@
 	@each $name, $_ in $flex-layout-media-queries {
 		@include flex-layout-media($name) {
 			*[data-fx-flex-#{$name}] {
-				@include flex-auto-properties;
+				@include flex-properties;
 			}
 
 			*[data-fx-flex-#{$name}="auto"] {
-				@include flex-properties;
+				@include flex-auto-properties;
 			}
 
 			*[data-fx-flex-#{$name}="grow"] {

--- a/src/lib/flex-classes.scss
+++ b/src/lib/flex-classes.scss
@@ -6,11 +6,31 @@
 		@include flex-properties;
 	}
 
+	*.fx-flex-auto {
+		@include flex-auto-properties;
+	}
+
 	*.fx-flex-grow {
 		@include flex-grow-properties;
 	}
 
-	*:has(>.fx-flex,>.fx-flex-grow):not([class*="fx-layout-"]) {
+	*.fx-flex-initial {
+		@include flex-initial-properties;
+	}
+
+	*.fx-flex-none {
+		@include flex-none-properties;
+	}
+
+	*.fx-flex-nogrow {
+		@include flex-nogrow-properties;
+	}
+
+	*.fx-flex-noshrink {
+		@include flex-noshrink-properties;
+	}
+
+	*:has(>.fx-flex,>.fx-flex-auto,>.fx-flex-grow,>.fx-flex-initial,>.fx-flex-none,>.fx-flex-nogrow,>.fx-flex-noshrink):not([class*="fx-layout-"]) {
 		@include flex-row-properties;
 	}
 }
@@ -23,11 +43,31 @@
 				@include flex-properties;
 			}
 
+			*.fx-flex-auto--#{$name} {
+				@include flex-auto-properties;
+			}
+		
 			*.fx-flex-grow--#{$name} {
 				@include flex-grow-properties;
 			}
+		
+			*.fx-flex-initial--#{$name} {
+				@include flex-initial-properties;
+			}
+		
+			*.fx-flex-none--#{$name} {
+				@include flex-none-properties;
+			}
+		
+			*.fx-flex-nogrow--#{$name} {
+				@include flex-nogrow-properties;
+			}
+		
+			*.fx-flex-noshrink--#{$name} {
+				@include flex-noshrink-properties;
+			}
 
-			*:has(>.fx-flex--#{$name},>.fx-flex-grow--#{$name}):not([class*="fx-layout-"]) {
+			*:has(>.fx-flex--#{$name},>.fx-flex-auto--#{$name},>.fx-flex-grow--#{$name},>.fx-flex-initial--#{$name},>.fx-flex-none--#{$name},>.fx-flex-nogrow--#{$name},>.fx-flex-noshrink--#{$name}):not([class*="fx-layout-"]) {
 				@include flex-row-properties;
 			}
 		}

--- a/src/lib/flex-classes.scss
+++ b/src/lib/flex-classes.scss
@@ -35,7 +35,7 @@
 	}
 }
 
-// in contrast to the attribute counterpart this can add flex to the parent container
+/// Generates flex class selectors for media sizes
 @mixin flex-classes-for-media-sizes {
 	@each $name, $_ in $flex-layout-media-queries {
 		@include flex-layout-media($name) {

--- a/src/lib/mixins.scss
+++ b/src/lib/mixins.scss
@@ -4,8 +4,28 @@
 	flex: 1 1 0;
 }
 
+@mixin flex-auto-properties {
+	flex-basis: auto;
+}
+
 @mixin flex-grow-properties {
-	flex: 1 1 auto;
+	flex: 1 1 100%;
+}
+
+@mixin flex-initial-properties {
+	flex: 0 1 auto;
+}
+
+@mixin flex-none-properties {
+	flex: 0 0 auto;
+}
+
+@mixin flex-nogrow-properties {
+	flex: 0 1 auto;
+}
+
+@mixin flex-noshrink-properties {
+	flex: 1 0 auto;
 }
 
 // Layout

--- a/src/lib/mixins.scss
+++ b/src/lib/mixins.scss
@@ -5,7 +5,7 @@
 }
 
 @mixin flex-auto-properties {
-	flex-basis: auto;
+	flex-basis: 100%;
 }
 
 @mixin flex-grow-properties {

--- a/test/index.html
+++ b/test/index.html
@@ -132,7 +132,7 @@
 		<tr>
 			<td>
 				<div>
-					<span data-fx-flex-none>Flex None</span>
+					<span data-fx-flex="none">Flex None</span>
 					<span data-fx-flex>Flex</span>
 					<span data-fx-flex-grow>Flex Grow</span>
 				</div>

--- a/test/index.html
+++ b/test/index.html
@@ -132,12 +132,14 @@
 		<tr>
 			<td>
 				<div>
+					<span data-fx-flex-none>Flex None</span>
 					<span data-fx-flex>Flex</span>
 					<span data-fx-flex-grow>Flex Grow</span>
 				</div>
 			</td>
 			<td>
 				<div>
+					<span class="fx-flex-none">Flex None</span>
 					<span class="fx-flex">Flex</span>
 					<span class="fx-flex-grow">Flex Grow</span>
 				</div>


### PR DESCRIPTION
Some additional improvements/questions:
- Currently we both support data-fx-flex-grow and data-fx-flex="grow" for attributes. Should we deprecate data-fx-flex-grow?
- Can we replace https://github.com/philmtd/css-fx-layout/blob/c0b3b022ab1ddf91181386ea8aa8f823157c1589/src/lib/flex-classes.scss#L13 by `*:has(>[class^="fx-flex"]):not([class*="fx-layout-"])` and remove these lines: https://github.com/philmtd/css-fx-layout/blob/c0b3b022ab1ddf91181386ea8aa8f823157c1589/src/lib/flex-classes.scss#L30-L32
- Is there a reason why we don't automatically add flex to the parent container of flex-attributes-for-media-sizes? https://github.com/philmtd/css-fx-layout/blob/c0b3b022ab1ddf91181386ea8aa8f823157c1589/src/lib/flex-attributes.scss#L18-L19

What do you think?