### PR TITLE
feat: add more flex layout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For example css-fx-layout provides attributes like the following, which can be c
 * `data-layout` and `data-layout-align`
 * `data-layout-gap`
 * `data-hide-...` and `data-show-...`
-* `data-fx-flex`
+* `data-flex`
 
 ### CSS class selectors
 

--- a/documentation/docs/about.md
+++ b/documentation/docs/about.md
@@ -29,7 +29,7 @@ Using the data attributes is the easiest way to use this library and easier to m
 * `data-layout` and `data-layout-align`: HTML attributes to be used to control the flexbox container
 * `data-layout-gap`: attribute to add gaps between the elements in a flex container
 * `data-hide-` and `data-show-`: attributes which can be used to show/hide elements depending on the screen size
-* `data-fx-flex` and `data-fx-flex-grow`: Control flex behaviour of an element
+* `data-flex`: Control flex behaviour of an element
 
 ### Responsive API
 

--- a/documentation/docs/attribute-selectors/flex.mdx
+++ b/documentation/docs/attribute-selectors/flex.mdx
@@ -5,11 +5,11 @@ sidebar_position: 3
 
 # Flex API
 
-This page describes how to use the attribute based flex API.
+This page describes how to use the attribute based flex APIs and supports three selectors: `data-flex`, `data-flex-fill` and `data-flex-align`.
 
 ## `data-flex` attribute
 
-The flex API consists of one attribute selector with the following available values and their resulting CSS:
+The `data-flex` attribute can take the following values with their resulting CSS:
 
 | Value        | CSS                 |
 |--------------|---------------------|
@@ -21,7 +21,7 @@ The flex API consists of one attribute selector with the following available val
 | `nogrow`     | `flex: 0 1 auto;`   |
 | `noshrink`   | `flex: 1 0 auto;`   |
 
-## Support for flex sizes
+### Support for flex sizes
 
 Additionally, you can generate flex size selectors using the mixins as shown in the following example. They will extend the `data-flex` attribute
 with numerical values, for example:
@@ -44,3 +44,28 @@ start and end and a given increment.
 The second mixin will generate only selectors for the numbers passed as the first argument.
 
 Both mixins can generate selectors for the responsive API (e.g. `data-flex-gt-sm="50"`)
+
+## `data-flex-fill` attribute
+
+The `data-flex-fill` attribute can be used to make a child of a flex-container fill the entire container.
+It takes no arguments and adds the following properties to the element:
+
+```css
+margin: 0;
+width: 100%;
+height: 100%;
+min-width: 100%;
+min-height: 100%;
+```
+
+## `data-flex-align` attribute
+
+The `data-flex-align` attribute takes the following values with their resulting CSS:
+
+| Value      | CSS                       |
+|------------|---------------------------|
+| `start`    | `align-self: flex-start;` |
+| `center`   | `align-self: center;`     |
+| `end`      | `align-self: flex-end;`   |
+| `baseline` | `align-self: baseline;`   |
+| `stretch`  | `align-self: stretch;`    |

--- a/documentation/docs/attribute-selectors/flex.mdx
+++ b/documentation/docs/attribute-selectors/flex.mdx
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 This page describes how to use the attribute based flex API.
 
-## `data-fx-flex` attribute
+## `data-flex` attribute
 
 The flex API consists of one attribute selector with the following available values and their resulting CSS:
 
@@ -23,13 +23,13 @@ The flex API consists of one attribute selector with the following available val
 
 ## Support for flex sizes
 
-Additionally, you can generate flex size selectors using the mixins as shown in the following example. They will extend the `data-fx-flex` attribute
+Additionally, you can generate flex size selectors using the mixins as shown in the following example. They will extend the `data-flex` attribute
 with numerical values, for example:
 
-| Selector                  | CSS                    |
-|---------------------------|------------------------|
-| `data-fx-flex="<number>"` | `flex: 1 1 <number>%;` |
-| e.g. `data-fx-flex="30"`  | `flex: 1 1 30%;`       |
+| Selector               | CSS                    |
+|------------------------|------------------------|
+| `data-flex="<number>"` | `flex: 1 1 <number>%;` |
+| e.g. `data-flex="30"`  | `flex: 1 1 30%;`       |
 
 This can be used to give elements a width with the percentage of the numerical value in relation to their flex container.
 
@@ -43,4 +43,4 @@ start and end and a given increment.
 
 The second mixin will generate only selectors for the numbers passed as the first argument.
 
-Both mixins can generate selectors for the responsive API (e.g. `data-fx-flex-gt-sm="50"`)
+Both mixins can generate selectors for the responsive API (e.g. `data-flex-gt-sm="50"`)

--- a/documentation/docs/attribute-selectors/responsive.md
+++ b/documentation/docs/attribute-selectors/responsive.md
@@ -29,6 +29,8 @@ The naming scheme is the following:
 * `data-layout-align-[mediaQueryName]`
 * `data-layout-gap-[mediaQueryName]`
 * `data-flex-[mediaQueryName]`
+* `data-flex-fill-[mediaQueryName]`
+* `data-flex-align-[mediaQueryName]`
 
 With the media query name being for example `xs` or `lt-md`. See  [this page](../responsive) for a full list.
 

--- a/documentation/docs/attribute-selectors/responsive.md
+++ b/documentation/docs/attribute-selectors/responsive.md
@@ -28,7 +28,7 @@ The naming scheme is the following:
 * `data-layout-[mediaQueryName]`
 * `data-layout-align-[mediaQueryName]`
 * `data-layout-gap-[mediaQueryName]`
-* `data-fx-flex-[mediaQueryName]`
+* `data-flex-[mediaQueryName]`
 
 With the media query name being for example `xs` or `lt-md`. See  [this page](../responsive) for a full list.
 

--- a/documentation/docs/attribute-selectors/show-hide.md
+++ b/documentation/docs/attribute-selectors/show-hide.md
@@ -14,6 +14,7 @@ The attributes have the following naming scheme:
 
 * `data-show-[mediaQueryName]`
 * `data-hide-[mediaQueryName]`
+* `data-hide`
 
 With `mediaQueryName` being the name of one of the [available media queries](../responsive#media-queries).
 

--- a/documentation/docs/attribute-selectors/show-hide.md
+++ b/documentation/docs/attribute-selectors/show-hide.md
@@ -17,6 +17,14 @@ The attributes have the following naming scheme:
 
 With `mediaQueryName` being the name of one of the [available media queries](../responsive#media-queries).
 
+:::caution Caution when using `data-show`
+
+Due to the way `data-show` works, it can only be used on an element once and never in combination with `data-hide`. If you require fine-grained control over
+when an element should be visible or not please only use `data-hide`! If you do not follow this advice your resulting layout will most likely not be
+what you wanted.
+
+:::
+
 ## Example
 
 ```html

--- a/documentation/docs/class-selectors/flex.mdx
+++ b/documentation/docs/class-selectors/flex.mdx
@@ -59,7 +59,7 @@ min-width: 100%;
 min-height: 100%;
 ```
 
-## `.fx-flex-align` selectors
+## `fx-flex-align` selectors
 
 We offer the following flex align classes with their resulting CSS:
 

--- a/documentation/docs/class-selectors/flex.mdx
+++ b/documentation/docs/class-selectors/flex.mdx
@@ -5,9 +5,10 @@ sidebar_position: 3
 
 # Flex API
 
-This page describes how to use the class based flex API.
+This page describes how to use the class based flex APIs and supports three
+types of class-selectors: `fx-flex`, `fx-flex-fill` and `fx-flex-align`.
 
-## Selectors
+## `fx-flex` classes
 
 The flex API consists of classes with the following names and their resulting CSS:
 
@@ -21,7 +22,7 @@ The flex API consists of classes with the following names and their resulting CS
 | `fx-flex-nogrow`   | `flex: 0 1 auto;`   |
 | `fx-flex-noshrink` | `flex: 1 0 auto;`   |
 
-## Support for flex sizes
+### Support for flex sizes
 
 Additionally, you can generate flex size selectors using the mixins as shown in the following example. They will extend the `fx-flex` classes
 with the following schema
@@ -44,3 +45,28 @@ start and end and a given increment.
 The second mixin will generate only selectors for the numbers passed as the first argument.
 
 Both mixins can generate selectors for the responsive API (e.g. `fx-flex--50--gt-sm`)
+
+## `fx-flex-fill` class
+
+The `fx-flex-fill` class can be used to make a child of a flex-container fill the entire container.
+It takes no arguments and adds the following properties to the element:
+
+```css
+margin: 0;
+width: 100%;
+height: 100%;
+min-width: 100%;
+min-height: 100%;
+```
+
+## `.fx-flex-align` selectors
+
+We offer the following flex align classes with their resulting CSS:
+
+| Value                     | CSS                       |
+|---------------------------|---------------------------|
+| `fx-flex-align--start`    | `align-self: flex-start;` |
+| `fx-flex-align--center`   | `align-self: center;`     |
+| `fx-flex-align--end`      | `align-self: flex-end;`   |
+| `fx-flex-align--baseline` | `align-self: baseline;`   |
+| `fx-flex-align--stretch`  | `align-self: stretch;`    |

--- a/documentation/docs/class-selectors/responsive.md
+++ b/documentation/docs/class-selectors/responsive.md
@@ -30,6 +30,8 @@ The naming scheme is the following:
 * `fx-align--*-[crossAxis]--[mediaQueryName]`
 * `fx-gap--[gapSize]--[mediaQueryName]`
 * `fx-flex-[flex]--[mediaQueryName]`
+* `fx-flex-fill--[mediaQueryName]`
+* `fx-flex-align--[fillSelector]--[mediaQueryName]`
 
 With the media query name being for example `xs` or `lt-md`. See  [this page](../responsive) for a full list.
 

--- a/documentation/docs/flex-layout-migration.mdx
+++ b/documentation/docs/flex-layout-migration.mdx
@@ -1,0 +1,59 @@
+---
+sidebar_label: Migration from Angular Flex-Layout
+sidebar_position: 6
+---
+
+# Migration from Angular Flex-Layout
+
+If you consider migrating to css-fx-layout from Angular Flex-Layout be sure to know this library's limitations.
+Not every feature of Flex-Layout is available but almost all popular features should be and some missing features can be
+easily replaced.
+
+As the migration is easier when you choose to use css-fx-layout with attribute selectors, this guide only focuses on this migration.
+
+## Limitations
+
+Let's start with what is missing in css-fx-layout in comparison with Angular Flex-Layout:
+
+* no JavaScript API
+* no support for Angular expression bindings
+* no alternative for `fxFlex` with numerical units other than percent
+* the alternatives for `fxFlexAlign` only support `start`, `center`, `end`, `baseline` and `stretch`
+* no grid functionality
+* no alternative for `fxFlexOrder`
+* no alternative for `fxFlexOffset`
+* no custom breakpoints
+
+There *may* be more differences in the details but these are the most obvious and big ones.
+
+## Migration
+
+:::info
+
+css-fx-layout generates some selectors only for the defined numerical values, for example the gap or flex selectors.
+Make sure to customise the parameters of the mixins in a way that generates all selectors you need in your project.
+
+:::
+
+Now that we got this out of the way let's migrate. Most of it should be possible to do with some smart
+finds and replaces in your code using regular expressions.
+
+| Flex-Layout selector       | Regex search               | Regex replace           |
+|----------------------------|----------------------------|-------------------------|
+| `fxLayout`                 | `fxLayout=`                | `data-layout=`          |
+| `fxLayout` responsive      | `fxLayout\.([\w-]+)=`      | `data-layout-$1=`       |
+| `fxLayoutAlign`            | `fxLayoutAlign=`           | `data-layout-align=`    |
+| `fxLayoutAlign` responsive | `fxLayoutAlign\.([\w-]+)=` | `data-layout-align-$1=` |
+| `fxFlex`                   | `fxFlex=`                  | `data-flex=`            |
+| `fxFlex` responsive        | `fxFlex\.([\w-]+)=`        | `data-flex-$1=`         |
+| `fxLayoutGap`              | `fxLayoutGap=`             | `data-layout-gap=`      |
+| `fxLayoutGap` responsive   | `fxLayoutGap\.([\w-]+)=`   | `data-layout-gap-$1=`   |
+| `fxHide` responsive        | `fxHide\.([\w-]+)`         | `data-hide-$1`          |
+| `fxShow` responsive        | `fxShow\.([\w-]+)`         | `data-show-$1`          |
+| `fxFlexFill`               | `fxFlexFill`               | `data-flex-fill`        |
+| `fxFlexFill` responsive    | `fxFlexFill\.([\w-]+)`     | `data-flex-fill-$1`     |
+
+Additionally, you need to replace all occurrences of `row-reverse` and `column-reverse` with `row reverse` or `column reverse`.
+
+This should get the migration of all available features done. In many projects, even larger ones, this will already be 90%-100% of the work required
+to move away from Angular Flex-Layout.

--- a/documentation/docs/flex-layout-migration.mdx
+++ b/documentation/docs/flex-layout-migration.mdx
@@ -23,6 +23,16 @@ Let's start with what is missing in css-fx-layout in comparison with Angular Fle
 * no alternative for `fxFlexOrder`
 * no alternative for `fxFlexOffset`
 * no custom breakpoints
+* the alternatives to `fxShow`/`fxHide` only support the responsive API
+* the alternative to `fxShow` does not work the same way it does in Flex-Layout
+
+:::warning Migrate away from `fxShow` / `data-show`
+
+When moving to css-fx-layout it is recommended to migrate all elements using `fxShow` with more than one media size or in combination with `fxHide` to multiple `data-hide` attributes.
+css-fx-layout is not a JavaScript powered library and cannot make the selectors work the same smart way they do in Angular Flex-Layout. Ignoring this advice and
+keeping multiple `data-show` attributes on your elements or trying to combine them with `data-hide` will very likely not result in what you want!
+
+:::
 
 There *may* be more differences in the details but these are the most obvious and big ones.
 
@@ -53,7 +63,11 @@ finds and replaces in your code using regular expressions.
 | `fxFlexFill`               | `fxFlexFill`               | `data-flex-fill`        |
 | `fxFlexFill` responsive    | `fxFlexFill\.([\w-]+)`     | `data-flex-fill-$1`     |
 
-Additionally, you need to replace all occurrences of `row-reverse` and `column-reverse` with `row reverse` or `column reverse`.
+Additionally:
+* you need to replace all occurrences of `row-reverse` and `column-reverse` with `row reverse` or `column reverse`
+* you should change your code to follow the advice regarding `data-show` from the warning box above
 
-This should get the migration of all available features done. In many projects, even larger ones, this will already be 90%-100% of the work required
+This should get the migration of all available features done. In many projects, even larger ones, this can already be 80-100% of the work required
 to move away from Angular Flex-Layout.
+
+Did we miss something? Feel free to contribute to the documentation or the library on [GitHub](https://github.com/philmtd/css-fx-layout).

--- a/documentation/docs/flex-layout-migration.mdx
+++ b/documentation/docs/flex-layout-migration.mdx
@@ -23,8 +23,7 @@ Let's start with what is missing in css-fx-layout in comparison with Angular Fle
 * no alternative for `fxFlexOrder`
 * no alternative for `fxFlexOffset`
 * no custom breakpoints
-* the alternatives to `fxShow`/`fxHide` only support the responsive API
-* the alternative to `fxShow` does not work the same way it does in Flex-Layout
+* the alternative to `fxShow` only supports the responsive API and does not work the same way it does in Flex-Layout
 
 :::warning Migrate away from `fxShow` / `data-show`
 

--- a/documentation/docs/flex-layout-migration.mdx
+++ b/documentation/docs/flex-layout-migration.mdx
@@ -16,7 +16,7 @@ As the migration is easier when you choose to use css-fx-layout with attribute s
 Let's start with what is missing in css-fx-layout in comparison with Angular Flex-Layout:
 
 * no JavaScript API
-* no support for Angular expression bindings
+* no general support for Angular expression bindings
 * no alternative for `fxFlex` with numerical units other than percent
 * the alternatives for `fxFlexAlign` only support `start`, `center`, `end`, `baseline` and `stretch`
 * no grid functionality

--- a/documentation/versioned_docs/version-2.1/attribute-selectors/show-hide.md
+++ b/documentation/versioned_docs/version-2.1/attribute-selectors/show-hide.md
@@ -17,6 +17,13 @@ The attributes have the following naming scheme:
 
 With `mediaQueryName` being the name of one of the [available media queries](../responsive#media-queries).
 
+:::caution
+
+Due to the way `data-show` works it can only be used on an element once and not in combination with `data-hide`. If you require fine-grained control over
+when an element should be visible or not please only use `data-hide`!
+
+:::
+
 ## Example
 
 ```html

--- a/src/fxlayout.scss
+++ b/src/fxlayout.scss
@@ -10,6 +10,8 @@
 @use "lib/flex-classes" as flexC;
 @use "lib/flex-size-attributes" as flexSizeA;
 @use "lib/flex-size-classes" as flexSizeC;
+@use "lib/flex-align-attributes" as flexAlignA;
+@use "lib/flex-align-classes" as flexAlignC;
 
 /// Adds the css-fx-layout class selectors, e.g. `.fx-layout-row`
 ///
@@ -20,11 +22,13 @@
 	@include layoutC.layout-classes;
 	@include layoutAlignC.layout-align-classes;
 	@include flexC.flex-classes;
+	@include flexAlignC.flex-align-classes;
 
 	@if $includeSelectorsForMediaSizes {
 		@include layoutC.layout-classes-for-media-sizes;
 		@include layoutAlignC.layout-align-classes-for-media-sizes;
 		@include flexC.flex-classes-for-media-sizes;
+		@include flexAlignC.flex-align-classes-for-media-sizes;
 	}
 }
 
@@ -89,11 +93,13 @@
 	@include layoutA.layout-attributes;
 	@include layoutAlignA.layout-align-attributes;
 	@include flexA.flex-attributes;
+	@include flexAlignA.flex-align-attributes;
 
 	@if $includeSelectorsForMediaSizes {
 		@include layoutA.layout-attributes-for-media-sizes;
 		@include layoutAlignA.layout-align-attributes-for-media-sizes;
 		@include flexA.flex-attributes-for-media-sizes;
+		@include flexAlignA.flex-align-attributes-for-media-sizes;
 	}
 }
 

--- a/src/lib/flex-align-attributes.scss
+++ b/src/lib/flex-align-attributes.scss
@@ -1,0 +1,42 @@
+@import "mixins";
+
+/// Generates flex align data attribute selectors
+@mixin flex-align-attributes {
+	*[data-flex-align="start"] {
+		@include flex-align-start-properties;
+	}
+	*[data-flex-align="center"] {
+		@include flex-align-center-properties;
+	}
+	*[data-flex-align="end"] {
+		@include flex-align-end-properties;
+	}
+	*[data-flex-align="baseline"] {
+		@include flex-align-baseline-properties;
+	}
+	*[data-flex-align="stretch"] {
+		@include flex-align-stretch-properties;
+	}
+}
+
+@mixin flex-align-attributes-for-media-sizes {
+	@each $name, $_ in $flex-layout-media-queries {
+		@include flex-layout-media($name) {
+			*[data-flex-align-#{$name}="start"] {
+				@include flex-align-start-properties;
+			}
+			*[data-flex-align-#{$name}="center"] {
+				@include flex-align-center-properties;
+			}
+			*[data-flex-align-#{$name}="end"] {
+				@include flex-align-end-properties;
+			}
+			*[data-flex-align-#{$name}="baseline"] {
+				@include flex-align-baseline-properties;
+			}
+			*[data-flex-align-#{$name}="stretch"] {
+				@include flex-align-stretch-properties;
+			}
+		}
+	}
+}

--- a/src/lib/flex-align-classes.scss
+++ b/src/lib/flex-align-classes.scss
@@ -1,6 +1,6 @@
 @import "mixins";
 
-/// Generates flex align data attribute selectors
+/// Generates flex align class selectors
 @mixin flex-align-classes {
 	*.fx-flex-align--start {
 		@include flex-align-start-properties;

--- a/src/lib/flex-align-classes.scss
+++ b/src/lib/flex-align-classes.scss
@@ -1,0 +1,42 @@
+@import "mixins";
+
+/// Generates flex align data attribute selectors
+@mixin flex-align-classes {
+	*.fx-flex-align--start {
+		@include flex-align-start-properties;
+	}
+	*.fx-flex-align--center {
+		@include flex-align-center-properties;
+	}
+	*.fx-flex-align--end {
+		@include flex-align-end-properties;
+	}
+	*.fx-flex-align--baseline {
+		@include flex-align-baseline-properties;
+	}
+	*.fx-flex-align--stretch {
+		@include flex-align-stretch-properties;
+	}
+}
+
+@mixin flex-align-classes-for-media-sizes {
+	@each $name, $_ in $flex-layout-media-queries {
+		@include flex-layout-media($name) {
+			*.fx-flex-align--start--#{$name} {
+				@include flex-align-start-properties;
+			}
+			*.fx-flex-align--center--#{$name} {
+				@include flex-align-center-properties;
+			}
+			*.fx-flex-align--end--#{$name} {
+				@include flex-align-end-properties;
+			}
+			*.fx-flex-align--baseline--#{$name} {
+				@include flex-align-baseline-properties;
+			}
+			*.fx-flex-align--stretch--#{$name} {
+				@include flex-align-stretch-properties;
+			}
+		}
+	}
+}

--- a/src/lib/flex-attributes.scss
+++ b/src/lib/flex-attributes.scss
@@ -2,43 +2,39 @@
 
 /// Generates flex data-attribute selectors
 @mixin flex-attributes {
-	*[data-fx-flex] {
+	*[data-flex] {
 		@include flex-properties;
 	}
 
-	*[data-fx-flex="auto"] {
+	*[data-flex="auto"] {
 		@include flex-auto-properties;
 	}
 
-	*[data-fx-flex="grow"] {
-		@include flex-grow-properties;
-	}
-
-	*[data-fx-flex-grow] {
+	*[data-flex="grow"] {
 		@include flex-grow-properties;
 	}
 	
-	*[data-fx-flex="initial"] {
+	*[data-flex="initial"] {
 		@include flex-initial-properties;
 	}
 
-	*[data-fx-flex="none"] {
+	*[data-flex="none"] {
 		@include flex-none-properties;
 	}
 	
-	*[data-fx-flex="nogrow"] {
+	*[data-flex="nogrow"] {
 		@include flex-nogrow-properties;
 	}
 	
-	*[data-fx-flex="noshrink"] {
+	*[data-flex="noshrink"] {
 		@include flex-noshrink-properties;
 	}
 
-	*[data-fx-flex-fill] {
+	*[data-flex-fill] {
 		@include flex-fill-properties;
 	}
 
-	*:has(>[data-fx-flex],>[data-fx-flex-grow],>[data-fx-flex-fill]):not([data-layout]) {
+	*:has(>[data-flex],>[data-flex-fill]):not([data-layout]) {
 		@include flex-row-properties;
 	}
 }
@@ -47,43 +43,39 @@
 @mixin flex-attributes-for-media-sizes {
 	@each $name, $_ in $flex-layout-media-queries {
 		@include flex-layout-media($name) {
-			*[data-fx-flex-#{$name}] {
+			*[data-flex-#{$name}] {
 				@include flex-properties;
 			}
 
-			*[data-fx-flex-#{$name}="auto"] {
+			*[data-flex-#{$name}="auto"] {
 				@include flex-auto-properties;
 			}
 
-			*[data-fx-flex-#{$name}="grow"] {
+			*[data-flex-#{$name}="grow"] {
 				@include flex-grow-properties;
 			}
 
-			*[data-fx-flex-grow-#{$name}] {
-				@include flex-grow-properties;
-			}
-
-			*[data-fx-flex-#{$name}="initial"] {
+			*[data-flex-#{$name}="initial"] {
 				@include flex-initial-properties;
 			}
 
-			*[data-fx-flex-#{$name}="none"] {
+			*[data-flex-#{$name}="none"] {
 				@include flex-none-properties;
 			}
 
-			*[data-fx-flex-#{$name}="nogrow"] {
+			*[data-flex-#{$name}="nogrow"] {
 				@include flex-nogrow-properties;
 			}
 
-			*[data-fx-flex-#{$name}="noshrink"] {
+			*[data-flex-#{$name}="noshrink"] {
 				@include flex-noshrink-properties;
 			}
 
-			*[data-fx-flex-fill-#{$name}] {
+			*[data-flex-fill-#{$name}] {
 				@include flex-fill-properties;
 			}
 
-			*:has(>[data-fx-flex-#{$name}],>[data-fx-flex-grow-#{$name}],>[data-fx-flex-fill-#{$name}]):not([data-layout]) {
+			*:has(>[data-flex-#{$name}],>[data-flex-fill-#{$name}]):not([data-layout]) {
 				@include flex-row-properties;
 			}
 		}

--- a/src/lib/flex-attributes.scss
+++ b/src/lib/flex-attributes.scss
@@ -34,7 +34,11 @@
 		@include flex-noshrink-properties;
 	}
 
-	*:has(>[data-fx-flex],>[data-fx-flex-grow]):not([data-layout]) {
+	*[data-fx-flex-fill] {
+		@include flex-fill-properties;
+	}
+
+	*:has(>[data-fx-flex],>[data-fx-flex-grow],>[data-fx-flex-fill]):not([data-layout]) {
 		@include flex-row-properties;
 	}
 }
@@ -75,7 +79,11 @@
 				@include flex-noshrink-properties;
 			}
 
-			*:has(>[data-fx-flex-#{$name}],>[data-fx-flex-grow-#{$name}]):not([data-layout]) {
+			*[data-fx-flex-fill-#{$name}] {
+				@include flex-fill-properties;
+			}
+
+			*:has(>[data-fx-flex-#{$name}],>[data-fx-flex-grow-#{$name}],>[data-fx-flex-fill-#{$name}]):not([data-layout]) {
 				@include flex-row-properties;
 			}
 		}

--- a/src/lib/flex-classes.scss
+++ b/src/lib/flex-classes.scss
@@ -30,7 +30,11 @@
 		@include flex-noshrink-properties;
 	}
 
-	*:has(>.fx-flex,>.fx-flex-auto,>.fx-flex-grow,>.fx-flex-initial,>.fx-flex-none,>.fx-flex-nogrow,>.fx-flex-noshrink):not([class*="fx-layout-"]) {
+	*.fx-flex-fill {
+		@include flex-fill-properties;
+	}
+
+	*:has(>.fx-flex,>.fx-flex-auto,>.fx-flex-grow,>.fx-flex-initial,>.fx-flex-none,>.fx-flex-nogrow,>.fx-flex-noshrink,>.fx-flex-fill):not([class*="fx-layout-"]) {
 		@include flex-row-properties;
 	}
 }
@@ -67,7 +71,11 @@
 				@include flex-noshrink-properties;
 			}
 
-			*:has(>.fx-flex--#{$name},>.fx-flex-auto--#{$name},>.fx-flex-grow--#{$name},>.fx-flex-initial--#{$name},>.fx-flex-none--#{$name},>.fx-flex-nogrow--#{$name},>.fx-flex-noshrink--#{$name}):not([class*="fx-layout-"]) {
+			*.fx-flex-fill--#{$name} {
+				@include flex-fill-properties;
+			}
+
+			*:has(>.fx-flex--#{$name},>.fx-flex-auto--#{$name},>.fx-flex-grow--#{$name},>.fx-flex-initial--#{$name},>.fx-flex-none--#{$name},>.fx-flex-nogrow--#{$name},>.fx-flex-noshrink--#{$name},>.fx-flex-fill--#{$name}):not([class*="fx-layout-"]) {
 				@include flex-row-properties;
 			}
 		}

--- a/src/lib/flex-size-attributes.scss
+++ b/src/lib/flex-size-attributes.scss
@@ -10,7 +10,7 @@
 /// @param {string} $name
 ///   Will generate selectors for a specific media size, e.g. xs, sm, md, ...
 @mixin flex-size-attribute($value, $name: false) {
-	*[data-fx-flex#{if($name, '-' + $name, '')}="#{$value}"] {
+	*[data-flex#{if($name, '-' + $name, '')}="#{$value}"] {
 		flex: 1 1 $value * 1%;
 	}
 }

--- a/src/lib/layout-align-attributes.scss
+++ b/src/lib/layout-align-attributes.scss
@@ -50,7 +50,7 @@
 		}
 	}
 
-	*:has([data-layout-align]):not([data-layout]) {
+	*[data-layout-align]:not([data-layout]) {
 		@include flex-row-properties;
 	}
 }

--- a/src/lib/layout-align-attributes.scss
+++ b/src/lib/layout-align-attributes.scss
@@ -49,6 +49,10 @@
 			align-items: stretch;
 		}
 	}
+
+	*:has([data-layout-align]):not([data-layout]) {
+		@include flex-row-properties;
+	}
 }
 
 @mixin layout-align-attributes-for-media-sizes {

--- a/src/lib/layout-align-classes.scss
+++ b/src/lib/layout-align-classes.scss
@@ -38,6 +38,10 @@
 	*.fx-align--x-stretch {
 		align-items: stretch;
 	}
+
+	*:has([class*="fx-align--"]):not([class*="fx-layout"]) {
+		@include flex-row-properties;
+	}
 }
 
 @mixin layout-align-classes-for-media-sizes {

--- a/src/lib/layout-align-classes.scss
+++ b/src/lib/layout-align-classes.scss
@@ -39,7 +39,7 @@
 		align-items: stretch;
 	}
 
-	*:has([class*="fx-align--"]):not([class*="fx-layout"]) {
+	*[class*="fx-align--"]:not([class*="fx-layout"]) {
 		@include flex-row-properties;
 	}
 }

--- a/src/lib/mixins.scss
+++ b/src/lib/mixins.scss
@@ -63,6 +63,28 @@
 
 }
 
+// Flex Align
+
+@mixin flex-align-start-properties {
+	align-self: flex-start;
+}
+
+@mixin flex-align-center-properties {
+	align-self: center;
+}
+
+@mixin flex-align-end-properties {
+	align-self: flex-end;
+}
+
+@mixin flex-align-baseline-properties {
+	align-self: baseline;
+}
+
+@mixin flex-align-stretch-properties {
+	align-self: stretch;
+}
+
 // Media Sizes
 // flex-layout breakpoints
 $xs: 599px;

--- a/src/lib/mixins.scss
+++ b/src/lib/mixins.scss
@@ -28,6 +28,14 @@
 	flex: 1 0 auto;
 }
 
+@mixin flex-fill-properties {
+	margin: 0;
+	width: 100%;
+	height: 100%;
+	min-width: 100%;
+	min-height: 100%
+}
+
 // Layout
 
 @mixin flex-row-properties {

--- a/src/lib/show-hide-attributes.scss
+++ b/src/lib/show-hide-attributes.scss
@@ -2,6 +2,9 @@
 
 /// Generates show/hide attribute selectors
 @mixin show-hide-attributes {
+	*[data-hide] {
+		display: none !important;
+	}
 	@each $breakpoint, $_ in $flex-layout-media-queries {
 		*[data-show-#{$breakpoint}] {
 			@include flex-layout-media-not($breakpoint) {

--- a/src/lib/show-hide-classes.scss
+++ b/src/lib/show-hide-classes.scss
@@ -2,6 +2,9 @@
 
 /// Generates show/hide class selectors
 @mixin show-hide-classes {
+	*.hide {
+		display: none !important;
+	}
 	@each $breakpoint, $_ in $flex-layout-media-queries {
 		*.show-#{$breakpoint} {
 			@include flex-layout-media-not($breakpoint) {

--- a/test/flex-size.spec.scss
+++ b/test/flex-size.spec.scss
@@ -8,10 +8,10 @@
 				@include fx.flex-size-attribute-selectors(5, 10)
 			}
 			@include true.expect {
-				*[data-fx-flex="5"] {
+				*[data-flex="5"] {
 					flex: 1 1 5%;
 				}
-				*[data-fx-flex="10"] {
+				*[data-flex="10"] {
 					flex: 1 1 10%;
 				}
 			}
@@ -38,13 +38,13 @@
 				@include fx.flex-size-attribute-selectors(2, 6, 2)
 			}
 			@include true.expect {
-				*[data-fx-flex="2"] {
+				*[data-flex="2"] {
 					flex: 1 1 2%;
 				}
-				*[data-fx-flex="4"] {
+				*[data-flex="4"] {
 					flex: 1 1 4%;
 				}
-				*[data-fx-flex="6"] {
+				*[data-flex="6"] {
 					flex: 1 1 6%;
 				}
 			}
@@ -74,10 +74,10 @@
 				@include fx.flex-size-attribute-selectors-from-list(28 42);
 			}
 			@include true.expect {
-				*[data-fx-flex="28"] {
+				*[data-flex="28"] {
 					flex: 1 1 28%;
 				}
-				*[data-fx-flex="42"] {
+				*[data-flex="42"] {
 					flex: 1 1 42%;
 				}
 			}

--- a/test/index.html
+++ b/test/index.html
@@ -426,16 +426,87 @@
 		<tr>
 			<td>
 				<div data-layout="row">
-					<span data-flex="20">One</span>
-					<span data-flex="30">Two</span>
-					<span data-flex="50">Three</span>
+					<span data-flex="20">20</span>
+					<span data-flex="30">30</span>
+					<span data-flex="50">50</span>
 				</div>
 			</td>
 			<td>
 				<div class="fx-layout-row ">
-					<span class="fx-flex--20">One</span>
-					<span class="fx-flex--30">Two</span>
-					<span class="fx-flex--50">Three</span>
+					<span class="fx-flex--20">20</span>
+					<span class="fx-flex--30">30</span>
+					<span class="fx-flex--50">50</span>
+				</div>
+			</td>
+		</tr>
+	</table>
+
+	<h2>Example E11</h2>
+	<p>Flex fill</p>
+	<table>
+		<tr>
+			<th>Attributes</th>
+			<th>Classes</th>
+		</tr>
+		<tr>
+			<td>
+				<div data-layout="row">
+					<span data-flex-fill>One</span>
+				</div>
+			</td>
+			<td>
+				<div class="fx-layout-row">
+					<span class="fx-flex-fill">One</span>
+				</div>
+			</td>
+		</tr>
+	</table>
+
+	<h2>Example E12</h2>
+	<p>Flex align</p>
+	<table>
+		<tr>
+			<th>Attributes</th>
+			<th>Classes</th>
+		</tr>
+		<tr>
+			<td>
+				<div data-layout="row">
+					<span data-flex data-flex-align="start">Start</span>
+					<span data-flex data-flex-align="center">Center</span>
+					<span data-flex data-flex-align="end">End</span>
+				</div>
+			</td>
+			<td>
+				<div class="fx-layout-row">
+					<span class="fx-flex fx-flex-align--start">Start</span>
+					<span class="fx-flex fx-flex-align--center">Center</span>
+					<span class="fx-flex fx-flex-align--end">End</span>
+				</div>
+			</td>
+		</tr>
+	</table>
+
+	<h2>Example E13</h2>
+	<p>Automatic flex-row if missing when flex-align is used</p>
+	<table>
+		<tr>
+			<th>Attributes</th>
+			<th>Classes</th>
+		</tr>
+		<tr>
+			<td>
+				<div data-layout-align="end center">
+					<span>One</span>
+					<span>Two</span>
+					<span>Three</span>
+				</div>
+			</td>
+			<td>
+				<div class="fx-align--end-x fx-align--x-center">
+					<span>One</span>
+					<span>Two</span>
+					<span>Three</span>
 				</div>
 			</td>
 		</tr>

--- a/test/index.html
+++ b/test/index.html
@@ -132,9 +132,9 @@
 		<tr>
 			<td>
 				<div>
-					<span data-fx-flex="none">Flex None</span>
-					<span data-fx-flex>Flex</span>
-					<span data-fx-flex-grow>Flex Grow</span>
+					<span data-flex="none">Flex None</span>
+					<span data-flex>Flex</span>
+					<span data-flex="grow">Flex Grow</span>
 				</div>
 			</td>
 			<td>
@@ -157,8 +157,8 @@
 		<tr>
 			<td>
 				<div data-layout="column">
-					<span data-fx-flex>Flex</span>
-					<span data-fx-flex-grow>Flex Grow</span>
+					<span data-flex>Flex</span>
+					<span data-flex="grow">Flex Grow</span>
 				</div>
 			</td>
 			<td>
@@ -323,8 +323,8 @@
 		<tr>
 			<td>
 				<div data-layout="row">
-					<span data-fx-flex-xs data-fx-flex-md data-fx-flex-xl>One</span>
-					<span class="green" data-fx-flex-sm data-fx-flex-lg>Two</span>
+					<span data-flex-xs data-flex-md data-flex-xl>One</span>
+					<span class="green" data-flex-sm data-flex-lg>Two</span>
 				</div>
 			</td>
 			<td>
@@ -426,9 +426,9 @@
 		<tr>
 			<td>
 				<div data-layout="row">
-					<span data-fx-flex="20">One</span>
-					<span data-fx-flex="30">Two</span>
-					<span data-fx-flex="50">Three</span>
+					<span data-flex="20">One</span>
+					<span data-flex="30">Two</span>
+					<span data-flex="50">Three</span>
 				</div>
 			</td>
 			<td>

--- a/test/show-hide.spec.scss
+++ b/test/show-hide.spec.scss
@@ -11,6 +11,9 @@
 				@include shc.show-hide-classes;
 			}
 			@include true.expect {
+				*.hide {
+					display: none !important;
+				}
 				@include mix.xs(true) {
 					*.show-xs {
 						display: none !important;
@@ -150,6 +153,9 @@
 				@include sha.show-hide-attributes;
 			}
 			@include true.expect {
+				*[data-hide] {
+					display: none !important;
+				}
 				@include mix.xs(true) {
 					*[data-show-xs] {
 						display: none !important;


### PR DESCRIPTION
This PR changes the following:
- adds an fxFlexFill alternative
- adds an fxFlexAlign alternative
- adds flex-row properties to containers where it is missing and where layout-align is used
- adds a documentation page on how to migrate from Flex Layout
- **renames `data-fx-flex` to `data-flex`** because it was the only attribute selector with the `fx` prefix, which was confusing
- removes `data-fx-flex-grow` in favor of `data-flex="grow"`

It introduces breaking changes, but as we already introduced other breaking changes for the next release this should be okay (as we're releasing it as the next major version).